### PR TITLE
Remove facets

### DIFF
--- a/Paginator/PaginatorAdapterInterface.php
+++ b/Paginator/PaginatorAdapterInterface.php
@@ -22,13 +22,6 @@ interface PaginatorAdapterInterface
     public function getResults($offset, $length);
 
     /**
-     * Returns Facets.
-     *
-     * @return mixed
-     */
-    public function getFacets();
-
-    /**
      * Returns Aggregations.
      *
      * @return mixed

--- a/Paginator/PartialResultsInterface.php
+++ b/Paginator/PartialResultsInterface.php
@@ -19,13 +19,6 @@ interface PartialResultsInterface
     public function getTotalHits();
 
     /**
-     * Returns the facets.
-     *
-     * @return array
-     */
-    public function getFacets();
-
-    /**
      * Returns the aggregations.
      *
      * @return array

--- a/Paginator/RawPaginatorAdapter.php
+++ b/Paginator/RawPaginatorAdapter.php
@@ -33,11 +33,6 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
     private $totalHits;
 
     /**
-     * @var array for the facets
-     */
-    private $facets;
-
-    /**
      * @var array for the aggregations
      */
     private $aggregations;
@@ -88,11 +83,6 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
 
         $resultSet = $this->searchable->search($query, $this->options);
         $this->totalHits = $resultSet->getTotalHits();
-
-        if (method_exists($resultSet, 'getFacets')) {
-            $this->facets = $resultSet->getFacets();
-        }
-        
         $this->aggregations = $resultSet->getAggregations();
 
         return $resultSet;
@@ -124,18 +114,6 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
         return $this->query->hasParam('size') && !$genuineTotal
             ? min($this->totalHits, (integer) $this->query->getParam('size'))
             : $this->totalHits;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFacets()
-    {
-        if (! isset($this->facets)) {
-            $this->facets = $this->searchable->search($this->query)->getFacets();
-        }
-
-        return $this->facets;
     }
 
     /**

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -36,20 +36,26 @@ $pagination = $paginator->paginate($results, $page, 10);
 Faceted Searching
 -----------------
 
-When searching with facets, the facets can be retrieved when using the paginated
+Facets have been removed from ElasticSearch 2.0. Please remove every reference to
+facets and use aggregations instead
+
+Aggregations
+------------
+
+When searching with aggregations, they can be retrieved when using the paginated
 methods on the finder.
 
 ```php
 $query = new \Elastica\Query();
-$facet = new \Elastica\Facet\Terms('tags');
-$facet->setField('companyGroup');
-$query->addFacet($facet);
+$agg = new \Elastica\Aggregation\Terms('tags');
+$agg->setField('companyGroup');
+$query->addAggregation($agg);
 
 $companies = $finder->findPaginated($query);
 $companies->setMaxPerPage($params['limit']);
 $companies->setCurrentPage($params['page']);
 
-$facets = $companies->getAdapter()->getFacets();
+$aggs = $companies->getAdapter()->getAggregations();
 ```
 
 Searching the entire index

--- a/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -42,10 +42,6 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
 
             $event->count = $results->getTotalHits();
             $event->items = $results->toArray();
-            $facets = $results->getFacets();
-            if (null != $facets) {
-                $event->setCustomPaginationParameter('facets', $facets);
-            }
             $aggregations = $results->getAggregations();
             if (null != $aggregations) {
                 $event->setCustomPaginationParameter('aggregations', $aggregations);

--- a/Tests/Subscriber/PaginateElasticaQuerySubscriberTest.php
+++ b/Tests/Subscriber/PaginateElasticaQuerySubscriberTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Fazland\ElasticaBundle\Tests\Subscriber;
+
+use Elastica\Aggregation\Terms;
+use Elastica\Query;
+use Fazland\ElasticaBundle\Paginator\RawPaginatorAdapter;
+use Fazland\ElasticaBundle\Subscriber\PaginateElasticaQuerySubscriber;
+use Knp\Component\Pager\Event\PaginationEvent;
+use Knp\Component\Pager\Pagination\SlidingPagination;
+use Knp\Component\Pager\Paginator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class PaginateElasticaQuerySubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    public function testShouldPaginate()
+    {
+        $subscriber = new PaginateElasticaQuerySubscriber();
+        $subscriber->setRequest(new Request());
+
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber($subscriber);
+        $dispatcher->addSubscriber(new MockPaginationSubscriber); // pagination view
+        $p = new Paginator($dispatcher);
+
+        $searchable = $this->getMockBuilder('Elastica\SearchableInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $self = $this;
+        $resultSet = $this->getMockBuilder('Elastica\ResultSet')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $resultSet->expects($this->any())
+            ->method('getTotalHits')
+            ->willReturn(100);
+        $resultSet->expects($this->any())
+            ->method('getResults')
+            ->willReturn([]);
+
+        $searchable->expects($this->once())
+            ->method('search')
+            ->willReturnCallback(function (Query $query) use ($self, $resultSet) {
+                $self->assertEquals(80, $query->getParam('from'));
+                $self->assertEquals(20, $query->getParam('size'));
+
+                return $resultSet;
+            });
+
+        $q = new Query(new Query\MatchAll());
+        $q->addAggregation(new Terms('term_agg'));
+
+        $adapter = new RawPaginatorAdapter($searchable, $q);
+
+        $p->paginate($adapter, 5, 20);
+    }
+}
+
+
+class MockPaginationSubscriber implements EventSubscriberInterface
+{
+    static function getSubscribedEvents()
+    {
+        return array(
+            'knp_pager.pagination' => array('pagination', 0)
+        );
+    }
+
+    function pagination(PaginationEvent $e)
+    {
+        $e->setPagination(new SlidingPagination());
+        $e->stopPropagation();
+    }
+}


### PR DESCRIPTION
Facets have been deprecated in ES 1.0 and removed in ES 2.0
- [x] Removed all facets refs from codebase
- [x] Add tests for `PaginateElasticaQuerySubscriber`
- [x] Update docs

This will fix #4 
