### PR TITLE
Refactoring repository manager

### DIFF
--- a/DependencyInjection/FazlandElasticaExtension.php
+++ b/DependencyInjection/FazlandElasticaExtension.php
@@ -612,13 +612,18 @@ class FazlandElasticaExtension extends Extension
             $container->setDefinition($finderId, $finderDef);
         }
 
-        $managerId = sprintf('fazland_elastica.manager.%s', $typeConfig['driver']);
-        $managerDef = $container->getDefinition($managerId);
-        $arguments = array( $typeConfig['model'], new Reference($finderId));
+        $indexTypeName = "$indexName/$typeName";
+        $arguments = [$indexTypeName, new Reference($finderId)];
         if (isset($typeConfig['repository'])) {
             $arguments[] = $typeConfig['repository'];
         }
-        $managerDef->addMethodCall('addEntity', $arguments);
+
+        $container->getDefinition('fazland_elastica.repository_manager')
+            ->addMethodCall('addType', $arguments);
+
+        $managerId = sprintf('fazland_elastica.manager.%s', $typeConfig['driver']);
+        $container->getDefinition($managerId)
+            ->addMethodCall('addEntity', [$indexTypeName]);
 
         return $finderId;
     }

--- a/DependencyInjection/FazlandElasticaExtension.php
+++ b/DependencyInjection/FazlandElasticaExtension.php
@@ -623,7 +623,7 @@ class FazlandElasticaExtension extends Extension
 
         $managerId = sprintf('fazland_elastica.manager.%s', $typeConfig['driver']);
         $container->getDefinition($managerId)
-            ->addMethodCall('addEntity', [$indexTypeName]);
+            ->addMethodCall('addEntity', [$typeConfig['model'], $indexTypeName]);
 
         return $finderId;
     }

--- a/Manager/RepositoryManager.php
+++ b/Manager/RepositoryManager.php
@@ -2,32 +2,38 @@
 
 namespace Fazland\ElasticaBundle\Manager;
 
-use Doctrine\Common\Annotations\Reader;
 use Fazland\ElasticaBundle\Finder\FinderInterface;
+use Fazland\ElasticaBundle\Repository;
 use RuntimeException;
 
 /**
- * @author Richard Miller <info@limethinking.co.uk>
- *
  * Allows retrieval of basic or custom repository for mapped Doctrine
  * entities/documents.
  */
 class RepositoryManager implements RepositoryManagerInterface
 {
-    protected $entities = array();
-    protected $repositories = array();
-    protected $reader;
+    /**
+     * @var array
+     */
+    private $types;
 
-    public function __construct(Reader $reader)
+    /**
+     * @var Repository[]
+     */
+    private $repositories;
+
+    public function __construct()
     {
-        $this->reader = $reader;
+        $this->types = [];
+        $this->repositories = [];
     }
 
-    public function addEntity($entityName, FinderInterface $finder, $repositoryName = null)
+    public function addType($indexTypeName, FinderInterface $finder, $repositoryName = null)
     {
-        $this->entities[$entityName] = array();
-        $this->entities[$entityName]['finder'] = $finder;
-        $this->entities[$entityName]['repositoryName'] = $repositoryName;
+        $this->types[$indexTypeName] = [
+            'finder' => $finder,
+            'repositoryName' => $repositoryName
+        ];
     }
 
     /**
@@ -35,57 +41,56 @@ class RepositoryManager implements RepositoryManagerInterface
      *
      * Returns custom repository if one specified otherwise
      * returns a basic repository.
+     *
+     * @param string $typeName
+     *
+     * @return Repository
      */
-    public function getRepository($entityName)
+    public function getRepository($typeName)
     {
-        if (isset($this->repositories[$entityName])) {
-            return $this->repositories[$entityName];
+        if (isset($this->repositories[$typeName])) {
+            return $this->repositories[$typeName];
         }
 
-        if (!isset($this->entities[$entityName])) {
-            throw new RuntimeException(sprintf('No search finder configured for %s', $entityName));
+        if (!isset($this->types[$typeName])) {
+            throw new RuntimeException(sprintf('No search finder configured for %s', $typeName));
         }
 
-        $repository = $this->createRepository($entityName);
-        $this->repositories[$entityName] = $repository;
+        $repository = $this->createRepository($typeName);
+        $this->repositories[$typeName] = $repository;
 
         return $repository;
     }
 
     /**
-     * @param string $entityName
+     * @param $typeName
      *
      * @return string
+     * @internal param string $entityName
+     *
      */
-    protected function getRepositoryName($entityName)
+    protected function getRepositoryName($typeName)
     {
-        if (isset($this->entities[$entityName]['repositoryName'])) {
-            return $this->entities[$entityName]['repositoryName'];
-        }
-
-        $refClass   = new \ReflectionClass($entityName);
-        $annotation = $this->reader->getClassAnnotation($refClass, 'Fazland\\ElasticaBundle\\Annotation\\Search');
-        if ($annotation) {
-            $this->entities[$entityName]['repositoryName']
-                = $annotation->repositoryClass;
-
-            return $annotation->repositoryClass;
+        if (isset($this->types[$typeName]['repositoryName'])) {
+            return $this->types[$typeName]['repositoryName'];
         }
 
         return 'Fazland\ElasticaBundle\Repository';
     }
 
     /**
-     * @param string $entityName
+     * @param $typeName
      *
      * @return mixed
+     * @internal param string $entityName
+     *
      */
-    private function createRepository($entityName)
+    private function createRepository($typeName)
     {
-        if (!class_exists($repositoryName = $this->getRepositoryName($entityName))) {
-            throw new RuntimeException(sprintf('%s repository for %s does not exist', $repositoryName, $entityName));
+        if (!class_exists($repositoryName = $this->getRepositoryName($typeName))) {
+            throw new RuntimeException(sprintf('%s repository for %s does not exist', $repositoryName, $typeName));
         }
 
-        return new $repositoryName($this->entities[$entityName]['finder']);
+        return new $repositoryName($this->types[$typeName]['finder']);
     }
 }

--- a/Manager/RepositoryManagerInterface.php
+++ b/Manager/RepositoryManagerInterface.php
@@ -3,6 +3,7 @@
 namespace Fazland\ElasticaBundle\Manager;
 
 use Fazland\ElasticaBundle\Finder\FinderInterface;
+use Fazland\ElasticaBundle\Repository;
 
 /**
  * @author Richard Miller <info@limethinking.co.uk>
@@ -13,14 +14,14 @@ use Fazland\ElasticaBundle\Finder\FinderInterface;
 interface RepositoryManagerInterface
 {
     /**
-     * Adds entity name and its finder.
+     * Adds type name and its finder.
      * Custom repository class name can also be added.
      *
-     * @param string $entityName
+     * @param string $indexTypeName The type name in "index/type" format
      * @param        $finder
      * @param string $repositoryName
      */
-    public function addEntity($entityName, FinderInterface $finder, $repositoryName = null);
+    public function addType($indexTypeName, FinderInterface $finder, $repositoryName = null);
 
     /**
      * Return repository for entity.
@@ -28,7 +29,9 @@ interface RepositoryManagerInterface
      * Returns custom repository if one specified otherwise
      * returns a basic repository.
      *
-     * @param string $entityName
+     * @param $typeName
+     *
+     * @return Repository
      */
-    public function getRepository($entityName);
+    public function getRepository($typeName);
 }

--- a/Resources/config/index.xml
+++ b/Resources/config/index.xml
@@ -12,9 +12,12 @@
         <parameter key="fazland_elastica.index_manager.class">Fazland\ElasticaBundle\Index\IndexManager</parameter>
         <parameter key="fazland_elastica.resetter.class">Fazland\ElasticaBundle\Index\Resetter</parameter>
         <parameter key="fazland_elastica.type.class">Elastica\Type</parameter>
+        <parameter key="fazland_elastica.repository_manager.class">Fazland\ElasticaBundle\Manager\RepositoryManager</parameter>
     </parameters>
 
     <services>
+        <service id="fazland_elastica.repository_manager" class="%fazland_elastica.repository_manager.class%" />
+
         <service id="fazland_elastica.alias_processor" class="%fazland_elastica.alias_processor.class%" />
 
         <service id="fazland_elastica.indexable" class="%fazland_elastica.indexable.class%">

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -43,7 +43,7 @@
 
         <service id="fazland_elastica.manager.orm" class="%fazland_elastica.manager.orm.class%">
             <argument type="service" id="doctrine" />
-            <argument type="service" id="annotation_reader" />
+            <argument type="service" id="fazland_elastica.repository_manager" />
         </service>
     </services>
 </container>

--- a/Tests/Doctrine/RepositoryManagerTest.php
+++ b/Tests/Doctrine/RepositoryManagerTest.php
@@ -3,6 +3,7 @@
 namespace Fazland\ElasticaBundle\Tests\Doctrine;
 
 use Fazland\ElasticaBundle\Doctrine\RepositoryManager;
+use Fazland\ElasticaBundle\Repository;
 
 class CustomRepository
 {
@@ -17,7 +18,7 @@ class Entity
  */
 class RepositoryManagerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testThatGetRepositoryReturnsDefaultRepository()
+    public function testThatGetRepositoryCallsMainRepositoryManager()
     {
         /** @var $finderMock \PHPUnit_Framework_MockObject_MockObject|\Fazland\ElasticaBundle\Finder\TransformedFinder */
         $finderMock = $this->getMockBuilder('Fazland\ElasticaBundle\Finder\TransformedFinder')
@@ -29,20 +30,23 @@ class RepositoryManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        /** @var $readerMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Annotations\Reader */
-        $readerMock = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
+        $mainManager = $this->getMockBuilder('Fazland\ElasticaBundle\Manager\RepositoryManagerInterface')
             ->disableOriginalConstructor()
             ->getMock();
 
+        $mainManager->method('getRepository')
+            ->with($this->equalTo('index/type'))
+            ->willReturn(new Repository($finderMock));
+
         $entityName = 'Fazland\ElasticaBundle\Tests\Manager\Entity';
 
-        $manager = new RepositoryManager($registryMock, $readerMock);
-        $manager->addEntity($entityName, $finderMock);
+        $manager = new RepositoryManager($registryMock, $mainManager);
+        $manager->addEntity($entityName, 'index/type');
         $repository = $manager->getRepository($entityName);
         $this->assertInstanceOf('Fazland\ElasticaBundle\Repository', $repository);
     }
 
-    public function testThatGetRepositoryReturnsCustomRepository()
+    public function testGetRepositoryShouldResolveEntityShortName()
     {
         /** @var $finderMock \PHPUnit_Framework_MockObject_MockObject|\Fazland\ElasticaBundle\Finder\TransformedFinder */
         $finderMock = $this->getMockBuilder('Fazland\ElasticaBundle\Finder\TransformedFinder')
@@ -54,103 +58,23 @@ class RepositoryManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        /** @var $readerMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Annotations\Reader */
-        $readerMock = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
+        $registryMock->method('getAliasNamespace')
+            ->with($this->equalTo('FazlandElasticaBundle'))
+            ->willReturn('Fazland\ElasticaBundle\Tests\Manager');
+
+        $mainManager = $this->getMockBuilder('Fazland\ElasticaBundle\Manager\RepositoryManagerInterface')
             ->disableOriginalConstructor()
             ->getMock();
+
+        $mainManager->method('getRepository')
+            ->with($this->equalTo('index/type'))
+            ->willReturn(new Repository($finderMock));
 
         $entityName = 'Fazland\ElasticaBundle\Tests\Manager\Entity';
 
-        $manager = new RepositoryManager($registryMock, $readerMock);
-        $manager->addEntity($entityName, $finderMock, 'Fazland\ElasticaBundle\Tests\Manager\CustomRepository');
-        $repository = $manager->getRepository($entityName);
-        $this->assertInstanceOf('Fazland\ElasticaBundle\Tests\Manager\CustomRepository', $repository);
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testThatGetRepositoryThrowsExceptionIfEntityNotConfigured()
-    {
-        /** @var $finderMock \PHPUnit_Framework_MockObject_MockObject|\Fazland\ElasticaBundle\Finder\TransformedFinder */
-        $finderMock = $this->getMockBuilder('Fazland\ElasticaBundle\Finder\TransformedFinder')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        /** @var $registryMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Persistence\ManagerRegistry */
-        $registryMock = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        /** @var $readerMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Annotations\Reader */
-        $readerMock = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entityName = 'Fazland\ElasticaBundle\Tests\Manager\Entity';
-
-        $manager = new RepositoryManager($registryMock, $readerMock);
-        $manager->addEntity($entityName, $finderMock);
-        $manager->getRepository('Missing Entity');
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testThatGetRepositoryThrowsExceptionIfCustomRepositoryNotFound()
-    {
-        /** @var $finderMock \PHPUnit_Framework_MockObject_MockObject|\Fazland\ElasticaBundle\Finder\TransformedFinder */
-        $finderMock = $this->getMockBuilder('Fazland\ElasticaBundle\Finder\TransformedFinder')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        /** @var $registryMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Persistence\ManagerRegistry */
-        $registryMock = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        /** @var $readerMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Annotations\Reader */
-        $readerMock = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entityName = 'Fazland\ElasticaBundle\Tests\Manager\Entity';
-
-        $manager = new RepositoryManager($registryMock, $readerMock);
-        $manager->addEntity($entityName, $finderMock, 'Fazland\ElasticaBundle\Tests\MissingRepository');
-        $manager->getRepository('Missing Entity');
-    }
-
-    public function testThatGetRepositoryWorksWithShortEntityName()
-    {
-        /** @var $finderMock \PHPUnit_Framework_MockObject_MockObject|\Fazland\ElasticaBundle\Finder\TransformedFinder */
-        $finderMock = $this->getMockBuilder('Fazland\ElasticaBundle\Finder\TransformedFinder')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        /** @var $registryMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Persistence\ManagerRegistry */
-        $registryMock = $this->getMockBuilder('Doctrine\Common\Persistence\ManagerRegistry')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        /** @var $readerMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Annotations\Reader */
-        $readerMock = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $shortEntityName = 'TestBundle:Entity';
-        $entityName = 'Fazland\ElasticaBundle\Tests\Manager\Entity';
-        $shortPath = 'TestBundle';
-        $fullPath = 'Fazland\ElasticaBundle\Tests\Manager';
-
-        $registryMock->expects($this->once())
-            ->method('getAliasNamespace')
-            ->with($this->equalTo($shortPath))
-            ->will($this->returnValue($fullPath));
-
-        $manager = new RepositoryManager($registryMock, $readerMock);
-        $manager->addEntity($entityName, $finderMock);
-        $repository = $manager->getRepository($shortEntityName);
+        $manager = new RepositoryManager($registryMock, $mainManager);
+        $manager->addEntity($entityName, 'index/type');
+        $repository = $manager->getRepository('FazlandElasticaBundle:Entity');
         $this->assertInstanceOf('Fazland\ElasticaBundle\Repository', $repository);
     }
 }

--- a/Tests/Functional/PersistenceRepositoryTest.php
+++ b/Tests/Functional/PersistenceRepositoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Fazland\ElasticaBundle\Tests\Functional;
+
+class PersistenceRepositoryTest extends WebTestCase
+{
+    public function testRepositoryShouldBeSetCorrectly()
+    {
+        $client = $this->createClient(array('test_case' => 'ORM'));
+
+        $repository = $client->getContainer()->get('fazland_elastica.manager.orm')
+            ->getRepository('Fazland\ElasticaBundle\Tests\Functional\TypeObject');
+
+        $this->assertNotNull($repository);
+        $this->assertEquals('Fazland\ElasticaBundle\Tests\Functional\TypeObjectRepository', get_class($repository));
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->deleteTmpDir('Basic');
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->deleteTmpDir('Basic');
+    }
+}

--- a/Tests/Functional/TypeObject.php
+++ b/Tests/Functional/TypeObject.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the FazlandElasticaBundle project.
+ *
+ * (c) Infinite Networks Pty Ltd <http://www.infinite.net.au>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Fazland\ElasticaBundle\Tests\Functional;
+
+class TypeObject
+{
+    public $id = 5;
+    public $coll;
+    public $field1;
+    public $field2;
+    public $field3;
+
+    public function isIndexable()
+    {
+        return true;
+    }
+
+    public function isntIndexable()
+    {
+        return false;
+    }
+
+    public function getSerializableColl()
+    {
+        return iterator_to_array($this->coll, false);
+    }
+}

--- a/Tests/Functional/TypeObjectRepository.php
+++ b/Tests/Functional/TypeObjectRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Fazland\ElasticaBundle\Tests\Functional;
+
+use Fazland\ElasticaBundle\Repository;
+
+class TypeObjectRepository extends Repository
+{
+}

--- a/Tests/Functional/app/ORM/config.yml
+++ b/Tests/Functional/app/ORM/config.yml
@@ -77,6 +77,16 @@ fazland_elastica:
                             property_path: coll
                         dynamic:
                             property_path: false
+                type_with_repository:
+                    properties:
+                        field1: ~
+                        coll: ~
+                    persistence:
+                        driver: orm
+                        model: Fazland\ElasticaBundle\Tests\Functional\TypeObject
+                        repository: Fazland\ElasticaBundle\Tests\Functional\TypeObjectRepository
+                        finder: ~
+                        provider: ~
         second_index:
             index_name: fazlandelastica_orm_test_second_%kernel.environment%
             types:

--- a/Tests/Manager/RepositoryManagerTest.php
+++ b/Tests/Manager/RepositoryManagerTest.php
@@ -29,11 +29,11 @@ class RepositoryManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $entityName = 'Fazland\ElasticaBundle\Tests\Manager\Entity';
+        $typeName = 'index/type';
 
         $manager = new RepositoryManager($readerMock);
-        $manager->addEntity($entityName, $finderMock);
-        $repository = $manager->getRepository($entityName);
+        $manager->addType($typeName, $finderMock);
+        $repository = $manager->getRepository($typeName);
         $this->assertInstanceOf('Fazland\ElasticaBundle\Repository', $repository);
     }
 
@@ -49,11 +49,11 @@ class RepositoryManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $entityName = 'Fazland\ElasticaBundle\Tests\Manager\Entity';
+        $typeName = 'index/type';
 
         $manager = new RepositoryManager($readerMock);
-        $manager->addEntity($entityName, $finderMock, 'Fazland\ElasticaBundle\Tests\Manager\CustomRepository');
-        $repository = $manager->getRepository($entityName);
+        $manager->addType($typeName, $finderMock, 'Fazland\ElasticaBundle\Tests\Manager\CustomRepository');
+        $repository = $manager->getRepository($typeName);
         $this->assertInstanceOf('Fazland\ElasticaBundle\Tests\Manager\CustomRepository', $repository);
     }
 
@@ -72,11 +72,11 @@ class RepositoryManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $entityName = 'Fazland\ElasticaBundle\Tests\Manager\Entity';
+        $typeName = 'index/type';
 
         $manager = new RepositoryManager($readerMock);
-        $manager->addEntity($entityName, $finderMock);
-        $manager->getRepository('Missing Entity');
+        $manager->addType($typeName, $finderMock);
+        $manager->getRepository('Missing type');
     }
 
     /**
@@ -94,10 +94,10 @@ class RepositoryManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $entityName = 'Fazland\ElasticaBundle\Tests\Manager\Entity';
+        $typeName = 'index/type';
 
         $manager = new RepositoryManager($readerMock);
-        $manager->addEntity($entityName, $finderMock, 'Fazland\ElasticaBundle\Tests\MissingRepository');
-        $manager->getRepository('Missing Entity');
+        $manager->addType($typeName, $finderMock, 'Fazland\ElasticaBundle\Tests\MissingRepository');
+        $manager->getRepository($typeName);
     }
 }


### PR DESCRIPTION
Currently there is no way to create more than one type associated with a model, each with its own repository class.
This PR adds this possibility, refactoring the `RepositoryManager` class

Now a repository can be retrieved through the `fazland_elastica.repository_manager` service calling `getRepository` method with `index/type` string as first argument.
Old doctrine repository manager class has been deprecated, but are still working as expected. 

BC breaks are present ONLY if the doctrine repository manager has been extended, while usage remains the same
