### PR TITLE
Remove unavailable mappings from parent transformation

### DIFF
--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -148,9 +148,9 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
 
         foreach ($fields as $key => $mapping) {
             if ($key == '_parent') {
-                $property = (null !== $mapping['property']) ? $mapping['property'] : $mapping['type'];
+                $property = $mapping['type'];
                 $value = $this->propertyAccessor->getValue($object, $property);
-                $document->setParent($this->propertyAccessor->getValue($value, $mapping['identifier']));
+                $document->setParent($this->propertyAccessor->getValue($value, $this->options['identifier']));
 
                 continue;
             }


### PR DESCRIPTION
`property` and `identifier` are no longer available mappings for the
`_parent` field (https://github.com/jarobe42/FazlandElasticaBundle/blob/87e905cfa1538c354e5a40ae61a09428986306ff/DependencyInjection/Configuration.php#L421-L421), so the transformer should not try to
access them.

Or should the mappings be reintroduced?
